### PR TITLE
Add support for other than c++ languages in code blocks

### DIFF
--- a/include/otdgen/DocCodeBlock.h
+++ b/include/otdgen/DocCodeBlock.h
@@ -31,12 +31,6 @@ class DocCodeBlock
 
 public:
 
-   enum class Type
-   {
-                  None,
-                  Cpp,
-   };
-
    enum class LineType
    {
                   Normal,
@@ -52,7 +46,7 @@ public:
    DocCodeBlock &   operator = (const DocCodeBlock & rhs) = default;
    DocCodeBlock &   operator = (DocCodeBlock && rhs) = default;
 
-   Type           type;
+   std::string    type;
    std::list <std::pair <std::string, LineType>>
                   lines;
 

--- a/src/GeneratorGitHubMarkDown.cpp
+++ b/src/GeneratorGitHubMarkDown.cpp
@@ -357,17 +357,10 @@ Name : process
 
 void  GeneratorGitHubMarkDown::process (std::string & output, std::vector <std::string> & /* cur */, const DocCodeBlock & codeblock)
 {
-   switch (codeblock.type)
-   {
-   case DocCodeBlock::Type::None:
-      output += "```\n";
-      break;
-
-   case DocCodeBlock::Type::Cpp:
-      output += "```c++\n";
-      break;
-   }
-
+   output += "```";
+   output += codeblock.type;
+   output += "\n";
+   
    for (auto && line : codeblock.lines)
    {
       output += line.first + "\n";

--- a/src/GeneratorPlainText.cpp
+++ b/src/GeneratorPlainText.cpp
@@ -322,16 +322,14 @@ void  GeneratorPlainText::process (std::string & output, std::vector <std::strin
 
    output += std::string (repetitions, '*');
 
-   switch (codeblock.type)
-   {
-   case DocCodeBlock::Type::None:
-      output += " code (unspecified language): \n";
-      break;
+   output += " code";
 
-   case DocCodeBlock::Type::Cpp:
-      output += " code (c++): \n";
-      break;
+   if (!codeblock.type.empty())
+   {
+      output += " (" + codeblock.type + ")";
    }
+
+   output += ":\n";
 
    for (auto && line : codeblock.lines)
    {

--- a/src/StructuralAnalyser.cpp
+++ b/src/StructuralAnalyser.cpp
@@ -518,16 +518,13 @@ void  StructuralAnalyser::process (const ExpressionCodeBlock & codeblock)
          _blocks_ptr->_content.end (), std::make_shared <DocCodeBlock> ()
       ));
 
-      block.type = DocCodeBlock::Type::None;
+      block.type = "";
 
       auto it = codeblock.options.find ("language");
 
       if (it != codeblock.options.end ())
       {
-         if (it->second == "c++")
-         {
-            block.type = DocCodeBlock::Type::Cpp;
-         }
+         block.type = it->second;
       }
 
       for (auto && line : codeblock.lines)


### PR DESCRIPTION
This PR adds support for other than c++ languages in code blocks.

This should allow, for example, having a code block containing `Swift` code to be properly highlighted when using the Github flavored Markdown output format of otdgen.

Fixes #11.